### PR TITLE
Build the att-doc-latences figure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ charts = diagrams/attestation-document-request-latency/att-doc-latencies.tex
 all: paper
 
 $(charts):
+	$(MAKE) -C $(dir $@)
 
 paper: $(deps) $(charts)
 	latexmk -pdflatex -quiet paper.tex


### PR DESCRIPTION
Have the top-level makefile build the included figure from the R plotting code and data. This should allow a fresh checkout of the paper to tex with a single `make` command.

Currently fails because data.csv isn't included in the repository, or computed from another step. Usually it's good to have non- deterministic data in the repo itself for consistency.